### PR TITLE
refactor: use with rules spa

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,5 @@
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
 build --enable_runfiles
+# Uncomment this and update the path when testing against rules_spa
+# build --override_repository=rules_spa=/path/to/rules_spa

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,9 +182,9 @@ multirun_dependencies()
 
 http_archive(
     name = "rules_spa",
-    sha256 = "d8f93861b7767274100c8716253cc2fa5f96a0fa3a26e333bdce2683d0411427",
-    strip_prefix = "rules_spa-0.0.4",
-    url = "https://github.com/aghassi/rules_spa/archive/v0.0.4.tar.gz",
+    sha256 = "6ba0bf70df5eeefcb3b8f414b5a6a9a362ae4874a888613450f8bfe223f05e7f",
+    strip_prefix = "rules_spa-0.0.5",
+    url = "https://github.com/aghassi/rules_spa/archive/v0.0.5.tar.gz",
 )
 
 # Fetches the rules_spa dependencies.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -179,3 +179,19 @@ git_repository(
 load("@com_github_ash2k_bazel_tools//multirun:deps.bzl", "multirun_dependencies")
 
 multirun_dependencies()
+
+http_archive(
+    name = "rules_spa",
+    sha256 = "d8f93861b7767274100c8716253cc2fa5f96a0fa3a26e333bdce2683d0411427",
+    strip_prefix = "rules_spa-0.0.4",
+    url = "https://github.com/aghassi/rules_spa/archive/v0.0.4.tar.gz",
+)
+
+# Fetches the rules_spa dependencies.
+# If you want to have a different version of some dependency,
+# you should fetch it *before* calling this.
+# Alternatively, you can skip calling this function, so long as you've
+# already fetched all the dependencies.
+load("@rules_spa//spa:repositories.bzl", "rules_spa_dependencies")
+
+rules_spa_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,9 +182,9 @@ multirun_dependencies()
 
 http_archive(
     name = "rules_spa",
-    sha256 = "6ba0bf70df5eeefcb3b8f414b5a6a9a362ae4874a888613450f8bfe223f05e7f",
-    strip_prefix = "rules_spa-0.0.5",
-    url = "https://github.com/aghassi/rules_spa/archive/v0.0.5.tar.gz",
+    sha256 = "b7cab8b052b6e2a5ed3822fb03c0db9785dfefd1d0bd3dcd4b151dadb6d583b0",
+    strip_prefix = "rules_spa-0.0.6",
+    url = "https://github.com/aghassi/rules_spa/archive/v0.0.6.tar.gz",
 )
 
 # Fetches the rules_spa dependencies.

--- a/bazel/js/internals/webpack/BUILD.bazel
+++ b/bazel/js/internals/webpack/BUILD.bazel
@@ -16,6 +16,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+exports_files(["webpack.module-federation.shared.js"])
+
 filegroup(
     name = "route_config",
     srcs = [

--- a/src/client/host/BUILD.bazel
+++ b/src/client/host/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//bazel/js:defaults.bzl", "build_host")
+load("@npm//webpack-cli:index.bzl", "webpack_cli")
+load("@rules_spa//spa:defs.bzl", "build_host")
 
 build_host(
     srcs = [
@@ -9,7 +10,11 @@ build_host(
         "host.tsx",
     ],
     data = [
+        "//:package.json",
         "//src/utils",
+        "@npm//:node_modules",
     ],
     entry = "host",
+    shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",
+    webpack = webpack_cli,
 )

--- a/src/client/routes/BUILD.bazel
+++ b/src/client/routes/BUILD.bazel
@@ -1,10 +1,17 @@
-load("//bazel/js:defaults.bzl", "build_module", "build_route", "pkg_web")
-load("@rules_spa//spa:defs.bzl", "generate_route_manifest")
+load("@npm//webpack-cli:index.bzl", "webpack_cli")
+load("//bazel/js:defaults.bzl", "build_module", "pkg_web")
+load("@rules_spa//spa:defs.bzl", "build_route", "generate_route_manifest")
 
 build_route(
     name = "default",
-    data = ["default.tsx"],
+    srcs = ["default.tsx"],
+    data = [
+        "//:package.json",
+        "@npm//:node_modules",
+    ],
     entry = "./$(execpath default.tsx)",
+    shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",
+    webpack = webpack_cli,
 )
 
 pkg_web(

--- a/src/client/routes/BUILD.bazel
+++ b/src/client/routes/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//bazel/js:defaults.bzl", "build_module", "build_route", "generate_route_manifest", "pkg_web")
+load("//bazel/js:defaults.bzl", "build_module", "build_route", "pkg_web")
+load("@rules_spa//spa:defs.bzl", "generate_route_manifest")
 
 build_route(
     name = "default",

--- a/src/client/routes/secondary/BUILD.bazel
+++ b/src/client/routes/secondary/BUILD.bazel
@@ -1,10 +1,17 @@
-load("//bazel/js:defaults.bzl", "build_route")
+load("@npm//webpack-cli:index.bzl", "webpack_cli")
+load("@rules_spa//spa:defs.bzl", "build_route")
 
 build_route(
     name = "secondary",
-    data = [
+    srcs = [
         "dep.tsx",
         "secondary.tsx",
     ],
+    data = [
+        "//:package.json",
+        "@npm//:node_modules",
+    ],
     entry = "./$(execpath secondary.tsx)",
+    shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",
+    webpack = webpack_cli,
 )

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//bazel/docker:defaults.bzl", "container_image", "container_layer")
-load("//bazel/js:defaults.bzl", "build_server", "js_library", "nodejs_binary", "pkg_web")
+load("//bazel/js:defaults.bzl", "nodejs_binary")
+load("@rules_spa//spa:defs.bzl", "build_server")
 
 build_server(
     name = "server",


### PR DESCRIPTION
This branch is going to change where the macros live as they are being moved to https://github.com/Aghassi/rules_spa. This will show how others can drop in the rules and use them in an existing application instead of having to define their own. 