### PR TITLE
feat: add redux context to module federation application

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,5 @@
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
 build --enable_runfiles
+# Uncomment this and update the path when testing against rules_spa
+# build --override_repository=rules_spa=/path/to/rules_spa

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@
 # Take care to document any settings that you expect users to apply.
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
-build --enable_runfiles
+build --enable_runfiles --incompatible_strict_action_env
+run --enable_runfiles --incompatible_strict_action_env
 # Uncomment this and update the path when testing against rules_spa
 # build --override_repository=rules_spa=/path/to/rules_spa

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,9 +182,9 @@ multirun_dependencies()
 
 http_archive(
     name = "rules_spa",
-    sha256 = "d8f93861b7767274100c8716253cc2fa5f96a0fa3a26e333bdce2683d0411427",
-    strip_prefix = "rules_spa-0.0.4",
-    url = "https://github.com/aghassi/rules_spa/archive/v0.0.4.tar.gz",
+    sha256 = "6ba0bf70df5eeefcb3b8f414b5a6a9a362ae4874a888613450f8bfe223f05e7f",
+    strip_prefix = "rules_spa-0.0.5",
+    url = "https://github.com/aghassi/rules_spa/archive/v0.0.5.tar.gz",
 )
 
 # Fetches the rules_spa dependencies.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -179,3 +179,19 @@ git_repository(
 load("@com_github_ash2k_bazel_tools//multirun:deps.bzl", "multirun_dependencies")
 
 multirun_dependencies()
+
+http_archive(
+    name = "rules_spa",
+    sha256 = "d8f93861b7767274100c8716253cc2fa5f96a0fa3a26e333bdce2683d0411427",
+    strip_prefix = "rules_spa-0.0.4",
+    url = "https://github.com/aghassi/rules_spa/archive/v0.0.4.tar.gz",
+)
+
+# Fetches the rules_spa dependencies.
+# If you want to have a different version of some dependency,
+# you should fetch it *before* calling this.
+# Alternatively, you can skip calling this function, so long as you've
+# already fetched all the dependencies.
+load("@rules_spa//spa:repositories.bzl", "rules_spa_dependencies")
+
+rules_spa_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,9 +182,9 @@ multirun_dependencies()
 
 http_archive(
     name = "rules_spa",
-    sha256 = "6ba0bf70df5eeefcb3b8f414b5a6a9a362ae4874a888613450f8bfe223f05e7f",
-    strip_prefix = "rules_spa-0.0.5",
-    url = "https://github.com/aghassi/rules_spa/archive/v0.0.5.tar.gz",
+    sha256 = "b7cab8b052b6e2a5ed3822fb03c0db9785dfefd1d0bd3dcd4b151dadb6d583b0",
+    strip_prefix = "rules_spa-0.0.6",
+    url = "https://github.com/aghassi/rules_spa/archive/v0.0.6.tar.gz",
 )
 
 # Fetches the rules_spa dependencies.

--- a/bazel/js/internals/routes.bzl
+++ b/bazel/js/internals/routes.bzl
@@ -25,7 +25,7 @@ def build_route(name, entry, data):
             name = "transpile_" + s.replace("//", "").replace("/", "_").split(".")[0],
             args = [
                 "-C jsc.parser.jsx=true",
-                "-C jsc.parser.typescript=true",
+                "-C jsc.parser.syntax=typescript",
                 "-C jsc.transform.react.runtime=automatic",
                 "-C jsc.transform.react.development=false",
                 "-C module.type=commonjs",

--- a/bazel/js/internals/webpack/BUILD.bazel
+++ b/bazel/js/internals/webpack/BUILD.bazel
@@ -16,6 +16,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+exports_files(["webpack.module-federation.shared.js"])
+
 filegroup(
     name = "route_config",
     srcs = [

--- a/package.json
+++ b/package.json
@@ -5,14 +5,17 @@
     "packages": []
   },
   "scripts": {
-    "build": "bazel build //...",
+    "build": "bazelisk build //...",
     "clean": "bazel clean",
+    "dev": "ibazel run //:dev",
     "prepare": "husky install"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "1.7.1",
     "http-server": "14.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-redux": "7.2.6",
     "react-router": "6.1.1",
     "react-router-dom": "6.1.1",
     "regenerator-runtime": "0.13.9"

--- a/src/client/host/BUILD.bazel
+++ b/src/client/host/BUILD.bazel
@@ -12,7 +12,11 @@ build_host(
     data = [
         "//:package.json",
         "//src/utils",
-        "@npm//:node_modules",
+        # "@npm//:node_modules",
+        "@npm//react-redux",
+        "@npm//react-router-dom",
+        "@npm//react",
+        "@npm//@reduxjs/toolkit",
     ],
     entry = "host",
     shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",

--- a/src/client/host/BUILD.bazel
+++ b/src/client/host/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//bazel/js:defaults.bzl", "build_host")
+load("@npm//webpack-cli:index.bzl", "webpack_cli")
+load("@rules_spa//spa:defs.bzl", "build_host")
 
 build_host(
     srcs = [
@@ -9,7 +10,11 @@ build_host(
         "host.tsx",
     ],
     data = [
+        "//:package.json",
         "//src/utils",
+        "@npm//:node_modules",
     ],
     entry = "host",
+    shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",
+    webpack = webpack_cli,
 )

--- a/src/client/host/bootstrap.tsx
+++ b/src/client/host/bootstrap.tsx
@@ -4,6 +4,8 @@ import ReactDOM from "react-dom";
 import FederatedRoute from "./FederatedRoute";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import { getRemoteEntryUrl } from "@carto/utils";
+import { store } from "@carto/utils/redux";
+import { Provider } from "react-redux";
 const path = window.location.pathname;
 // Find a better way to hydrate this as it isn't really "clean"
 const config = window.config;
@@ -52,12 +54,14 @@ function NoMatch() {
 // root element is defined on the server side
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        {reactRouterRoutes}
-        <Route path="*" element={<NoMatch />} />
-      </Routes>
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <Routes>
+          {reactRouterRoutes}
+          <Route path="*" element={<NoMatch />} />
+        </Routes>
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/client/host/capabilities/getIdentifier.ts
+++ b/src/client/host/capabilities/getIdentifier.ts
@@ -1,2 +1,0 @@
-export default (path) =>
-  path === "/" || typeof path === "undefined" ? "default" : path;

--- a/src/client/routes/BUILD.bazel
+++ b/src/client/routes/BUILD.bazel
@@ -1,10 +1,17 @@
-load("//bazel/js:defaults.bzl", "build_module", "build_route", "pkg_web")
-load("@rules_spa//spa:defs.bzl", "generate_route_manifest")
+load("@npm//webpack-cli:index.bzl", "webpack_cli")
+load("//bazel/js:defaults.bzl", "build_module", "pkg_web")
+load("@rules_spa//spa:defs.bzl", "build_route", "generate_route_manifest")
 
 build_route(
     name = "default",
-    data = ["default.tsx"],
+    srcs = ["default.tsx"],
+    data = [
+        "//:package.json",
+        "@npm//:node_modules",
+    ],
     entry = "./$(execpath default.tsx)",
+    shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",
+    webpack = webpack_cli,
 )
 
 pkg_web(

--- a/src/client/routes/BUILD.bazel
+++ b/src/client/routes/BUILD.bazel
@@ -8,7 +8,11 @@ build_route(
     data = [
         "//:package.json",
         "//src/utils",
-        "@npm//:node_modules",
+        # "@npm//:node_modules",
+        "@npm//react-redux",
+        "@npm//react-router-dom",
+        "@npm//react",
+        "@npm//@reduxjs/toolkit",
     ],
     entry = "./$(execpath default.tsx)",
     shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",

--- a/src/client/routes/BUILD.bazel
+++ b/src/client/routes/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//bazel/js:defaults.bzl", "build_module", "build_route", "generate_route_manifest", "pkg_web")
+load("//bazel/js:defaults.bzl", "build_module", "build_route", "pkg_web")
+load("@rules_spa//spa:defs.bzl", "generate_route_manifest")
 
 build_route(
     name = "default",

--- a/src/client/routes/BUILD.bazel
+++ b/src/client/routes/BUILD.bazel
@@ -7,6 +7,7 @@ build_route(
     srcs = ["default.tsx"],
     data = [
         "//:package.json",
+        "//src/utils",
         "@npm//:node_modules",
     ],
     entry = "./$(execpath default.tsx)",

--- a/src/client/routes/default.tsx
+++ b/src/client/routes/default.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
-import { RootState } from "@carto/utils/redux";
 import { decrement, increment } from "@carto/utils/redux/counterSlice";
+import { getCounterSelector } from "@carto/utils/redux";
 
 /**
  * Defines a main route
  */
 export default () => {
-  const count = useSelector((state) => state.counter.value);
+  const count = useSelector(getCounterSelector);
   const dispatch = useDispatch();
 
   return (

--- a/src/client/routes/default.tsx
+++ b/src/client/routes/default.tsx
@@ -1,13 +1,34 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { RootState } from "@carto/utils/redux";
+import { decrement, increment } from "@carto/utils/redux/counterSlice";
 
 /**
  * Defines a main route
  */
-export default () => (
-  <div>
-    Main Route
-    <br></br>
-    <Link to="/secondary">Go to second page</Link>
-  </div>
-);
+export default () => {
+  const count = useSelector((state) => state.counter.value);
+  const dispatch = useDispatch();
+
+  return (
+    <div>
+      Main Route
+      <br></br>
+      <Link to="/secondary">Go to second page</Link>
+      <button
+        aria-label="Increment value"
+        onClick={() => dispatch(increment())}
+      >
+        Increment
+      </button>
+      <span>{count}</span>
+      <button
+        aria-label="Decrement value"
+        onClick={() => dispatch(decrement())}
+      >
+        Decrement
+      </button>
+    </div>
+  );
+};

--- a/src/client/routes/secondary/BUILD.bazel
+++ b/src/client/routes/secondary/BUILD.bazel
@@ -9,6 +9,7 @@ build_route(
     ],
     data = [
         "//:package.json",
+        "//src/utils",
         "@npm//:node_modules",
     ],
     entry = "./$(execpath secondary.tsx)",

--- a/src/client/routes/secondary/BUILD.bazel
+++ b/src/client/routes/secondary/BUILD.bazel
@@ -1,10 +1,17 @@
-load("//bazel/js:defaults.bzl", "build_route")
+load("@npm//webpack-cli:index.bzl", "webpack_cli")
+load("@rules_spa//spa:defs.bzl", "build_route")
 
 build_route(
     name = "secondary",
-    data = [
+    srcs = [
         "dep.tsx",
         "secondary.tsx",
     ],
+    data = [
+        "//:package.json",
+        "@npm//:node_modules",
+    ],
     entry = "./$(execpath secondary.tsx)",
+    shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",
+    webpack = webpack_cli,
 )

--- a/src/client/routes/secondary/BUILD.bazel
+++ b/src/client/routes/secondary/BUILD.bazel
@@ -10,7 +10,11 @@ build_route(
     data = [
         "//:package.json",
         "//src/utils",
-        "@npm//:node_modules",
+        # "@npm//:node_modules",
+        "@npm//react-redux",
+        "@npm//react-router-dom",
+        "@npm//react",
+        "@npm//@reduxjs/toolkit",
     ],
     entry = "./$(execpath secondary.tsx)",
     shared = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",

--- a/src/client/routes/secondary/secondary.tsx
+++ b/src/client/routes/secondary/secondary.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import { Link } from "react-router-dom";
 import SubComponent from "./dep";
 import { useSelector } from "react-redux";
+import { getCounterSelector } from "@carto/utils/redux";
 /**
  * Defines a secondary route
  */
 
 export default () => {
-  const count = useSelector((state) => state.counter.value);
+  const count = useSelector(getCounterSelector);
 
   return (
     <div>

--- a/src/client/routes/secondary/secondary.tsx
+++ b/src/client/routes/secondary/secondary.tsx
@@ -1,14 +1,20 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import SubComponent from "./dep";
+import { useSelector } from "react-redux";
 /**
  * Defines a secondary route
  */
 
-export default () => (
-  <div>
-    Secondary Route. <SubComponent />
-    <br></br>
-    <Link to="/">Go to homepage</Link>
-  </div>
-);
+export default () => {
+  const count = useSelector((state) => state.counter.value);
+
+  return (
+    <div>
+      Secondary Route. <SubComponent />
+      <br></br>
+      <Link to="/">Go to homepage</Link>
+      <span>{count}</span>
+    </div>
+  );
+};

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//bazel/docker:defaults.bzl", "container_image", "container_layer")
-load("//bazel/js:defaults.bzl", "build_server", "js_library", "nodejs_binary", "pkg_web")
+load("//bazel/js:defaults.bzl", "nodejs_binary")
+load("@rules_spa//spa:defs.bzl", "build_server")
 
 build_server(
     name = "server",

--- a/src/utils/BUILD.bazel
+++ b/src/utils/BUILD.bazel
@@ -5,9 +5,13 @@ build_module(
     package_name = "@carto/utils",
     srcs = [
         "index.ts",
+        "redux/counterSlice.ts",
+        "redux/index.ts",
+        "redux/store.ts",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "@npm//@reduxjs/toolkit",
         "@npm//@types/node",
     ],
 )

--- a/src/utils/redux/counterSlice.ts
+++ b/src/utils/redux/counterSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export interface CounterState {
+  value: number;
+}
+
+const initialState: CounterState = {
+  value: 0,
+};
+
+export const counterSlice = createSlice({
+  name: "counter",
+  initialState,
+  reducers: {
+    increment: (state) => {
+      // Redux Toolkit allows us to write "mutating" logic in reducers. It
+      // doesn't actually mutate the state because it uses the Immer library,
+      // which detects changes to a "draft state" and produces a brand new
+      // immutable state based off those changes
+      state.value += 1;
+    },
+    decrement: (state) => {
+      state.value -= 1;
+    },
+    incrementByAmount: (state, action: PayloadAction<number>) => {
+      state.value += action.payload;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { increment, decrement, incrementByAmount } = counterSlice.actions;
+
+export default counterSlice.reducer;

--- a/src/utils/redux/counterSlice.ts
+++ b/src/utils/redux/counterSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "./store";
 
 export interface CounterState {
   value: number;
@@ -30,5 +31,8 @@ export const counterSlice = createSlice({
 
 // Action creators are generated for each case reducer function
 export const { increment, decrement, incrementByAmount } = counterSlice.actions;
+
+export const getCounterSelector = (state: RootState): number =>
+  state.counter.value;
 
 export default counterSlice.reducer;

--- a/src/utils/redux/index.ts
+++ b/src/utils/redux/index.ts
@@ -1,0 +1,1 @@
+export * from "./store";

--- a/src/utils/redux/index.ts
+++ b/src/utils/redux/index.ts
@@ -1,1 +1,3 @@
 export * from "./store";
+
+export { getCounterSelector } from "./counterSlice";

--- a/src/utils/redux/store.ts
+++ b/src/utils/redux/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import counterReducer from "./counterSlice";
+
+export const store = configureStore({
+  reducer: {
+    counter: counterReducer,
+  },
+});
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.15.4", "@babel/runtime@^7.9.2":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.7.6":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
@@ -95,6 +102,16 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/@protobufjs/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@reduxjs/toolkit@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.7.1.tgz#994962aeb7df3c77be343dd2ad1aa48221dbaa0c"
+  integrity sha512-wXwXYjBVz/ItxB7SMzEAMmEE/FBiY1ze18N+VVVX7NtVbRUrdOGKhpQMHivIJfkbJvSdLUU923a/yAagJQzY0Q==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.1.tgz#8dc390a7b4f9dd9f1284629efce982e41612116e"
@@ -115,6 +132,14 @@
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.8":
   version "7.0.9"
@@ -140,6 +165,35 @@
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=
+
+"@types/prop-types@*":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
+"@types/react-redux@^7.1.20":
+  version "7.1.22"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
+  integrity sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*":
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -504,6 +558,11 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+csstype@^3.0.2:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
+
 debug@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -711,6 +770,13 @@ history@^5.1.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
@@ -762,6 +828,11 @@ iconv-lite@0.6.3:
   integrity sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+immer@^9.0.7:
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
+  integrity sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==
 
 import-local@^3.0.2:
   version "3.0.3"
@@ -925,7 +996,7 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha1-mntxz7fTYaGU6lVSQckvdGjVvyg=
 
-loose-envify@^1.1.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1134,6 +1205,15 @@ prettier@2.5.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
+prop-types@^15.7.2:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 protobufjs@6.8.8:
   version "6.8.8"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
@@ -1181,6 +1261,28 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-is@^16.13.1, react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-redux@7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
+
 react-router-dom@6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.1.1.tgz#ed59376ff9115bc49227e87982a32e91e9530ca3"
@@ -1211,6 +1313,18 @@ rechoir@^0.7.0:
   dependencies:
     resolve "^1.9.0"
 
+redux-thunk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
+redux@^4.0.0, redux@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 regenerator-runtime@0.13.9, regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -1220,6 +1334,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Demo elements

- Redux toolkit slices
- Exposed Redux store from @carto/utils so it can be propagated across routes and host
  - follow-up would be to make this it's own module so it scopes redux cache invalidations. Each redux slice could also be it's own target as well. 
- State propagated across routes

## Limitations

- Normally the `@carto/utils/redux` route will expose types for the reducer and the store to help with intellisense. However, this doesn't work with our current SWC config, which seems to not be transpiling it as TS. I think the change [here](https://github.com/Aghassi/bazel-module-federation/compare/example/use-with-rules-spa...demo/redux-state?expand=1#diff-84fb8571cf101e47c4e57556ecbabc7482eb95a5e62f595b59d8ff1336d98182R28) upstream would fix it.