### PR TITLE
demo: esbuild module in graph

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,10 @@ yarn_install(
     yarn_lock = "//:yarn.lock",
 )
 
+load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
+
+esbuild_repositories(npm_repository = "npm")
+
 http_archive(
     name = "aspect_rules_swc",
     sha256 = "67d6020374627f60c6c1e5d5e1690fcdc4fa39952de8a727d3aabe265ca843be",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,9 +42,9 @@ esbuild_repositories(npm_repository = "npm")
 
 http_archive(
     name = "aspect_rules_swc",
-    sha256 = "67d6020374627f60c6c1e5d5e1690fcdc4fa39952de8a727d3aabe265ca843be",
-    strip_prefix = "rules_swc-0.1.0",
-    url = "https://github.com/aspect-build/rules_swc/archive/v0.1.0.tar.gz",
+    sha256 = "b58c8f3681215af30842bc3eeec30c9d2047cdf63302bba7d2e86c55a5c77edf",
+    strip_prefix = "rules_swc-0.3.1",
+    url = "https://github.com/aspect-build/rules_swc/archive/refs/tags/v0.3.1.tar.gz",
 )
 
 # Fetches the rules_swc dependencies.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,6 +30,7 @@ yarn_install(
     links = {
         "@carto/utils": "//src/utils",
         "@carto/routes": "//src/client/routes",
+        "@internal/404": "//src/client/host/404:@internal/404",
     },
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",

--- a/bazel/js/defaults.bzl
+++ b/bazel/js/defaults.bzl
@@ -1,8 +1,10 @@
 load("//bazel/js/internals:module.bzl", _build_module = "build_module")
 load("@build_bazel_rules_nodejs//:index.bzl", _js_library = "js_library", _nodejs_binary = "nodejs_binary", _pkg_web = "pkg_web")
+load("@npm//@bazel/esbuild:index.bzl", _esbuild = "esbuild")
 
 # export so the load statement hits the default path
 build_module = _build_module
 pkg_web = _pkg_web
 js_library = _js_library
 nodejs_binary = _nodejs_binary
+esbuild = _esbuild

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@bazel/bazelisk": "1.10.1",
+    "@bazel/esbuild": "4.6.0",
     "@bazel/ibazel": "0.15.10",
     "@bazel/typescript": "4.4.6",
     "@types/node": "16.11.11",

--- a/src/client/host/404/404.tsx
+++ b/src/client/host/404/404.tsx
@@ -11,3 +11,12 @@ export function NoMatch() {
     </div>
   );
 }
+
+/**
+ * This function exists to prove that the bundler
+ * will eliminate this code when the package is consumed
+ * by webpack and bundled
+ */
+export function DeadCode() {
+  return <div></div>;
+}

--- a/src/client/host/404/404.tsx
+++ b/src/client/host/404/404.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Link } from "react-router-dom";
 
 export function NoMatch() {

--- a/src/client/host/404/404.tsx
+++ b/src/client/host/404/404.tsx
@@ -18,5 +18,9 @@ export function NoMatch() {
  * by webpack and bundled
  */
 export function DeadCode() {
-  return <div></div>;
+  return (
+    <div>
+      <h2>What is dead may never die</h2>
+    </div>
+  );
 }

--- a/src/client/host/404/404.tsx
+++ b/src/client/host/404/404.tsx
@@ -1,0 +1,13 @@
+import { Link } from "react-router-dom";
+
+export function NoMatch() {
+  return (
+    <div>
+      <h2>Nothing to see here!</h2>
+      <br></br>
+      <p>
+        <Link to="/">Go to the home page</Link>
+      </p>
+    </div>
+  );
+}

--- a/src/client/host/404/BUILD.bazel
+++ b/src/client/host/404/BUILD.bazel
@@ -3,6 +3,7 @@ load("//bazel/js:defaults.bzl", "esbuild")
 esbuild(
     name = "404",
     entry_point = "404.tsx",
+    format = "esm",
     minify = False,
     splitting = False,
     target = "esnext",

--- a/src/client/host/404/BUILD.bazel
+++ b/src/client/host/404/BUILD.bazel
@@ -3,6 +3,7 @@ load("//bazel/js:defaults.bzl", "esbuild")
 esbuild(
     name = "404",
     entry_point = "404.tsx",
+    external = ["react-router-dom"],
     format = "esm",
     minify = False,
     splitting = False,

--- a/src/client/host/404/BUILD.bazel
+++ b/src/client/host/404/BUILD.bazel
@@ -3,7 +3,10 @@ load("//bazel/js:defaults.bzl", "esbuild", "js_library")
 esbuild(
     name = "404",
     entry_point = "404.tsx",
-    external = ["react-router-dom"],
+    external = [
+        "react",
+        "react-router-dom",
+    ],
     format = "esm",
     minify = False,
     output = "index.mjs",

--- a/src/client/host/404/BUILD.bazel
+++ b/src/client/host/404/BUILD.bazel
@@ -1,0 +1,11 @@
+load("//bazel/js:defaults.bzl", "esbuild")
+
+esbuild(
+    name = "404",
+    entry_point = "404.tsx",
+    minify = False,
+    splitting = False,
+    target = "esnext",
+    visibility = ["//src/client/host:__pkg__"],
+    deps = ["@npm//:node_modules"],
+)

--- a/src/client/host/404/BUILD.bazel
+++ b/src/client/host/404/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel/js:defaults.bzl", "esbuild")
+load("//bazel/js:defaults.bzl", "esbuild", "js_library")
 
 esbuild(
     name = "404",
@@ -6,8 +6,17 @@ esbuild(
     external = ["react-router-dom"],
     format = "esm",
     minify = False,
+    output = "index.mjs",
     splitting = False,
     target = "esnext",
-    visibility = ["//src/client/host:__pkg__"],
     deps = ["@npm//:node_modules"],
+)
+
+js_library(
+    name = "@internal/404",
+    srcs = [
+        "package.json",
+        ":404",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/src/client/host/404/package.json
+++ b/src/client/host/404/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@internal/404",
+  "type": "module",
+  "main": "index.mjs",
+  "sideEffects": false
+}

--- a/src/client/host/BUILD.bazel
+++ b/src/client/host/BUILD.bazel
@@ -11,9 +11,9 @@ build_host(
     ],
     data = [
         "//:package.json",
-        "//src/client/host/404",
         "@npm//:node_modules",
         "@npm//@carto/utils",
+        "@npm//@internal/404",
     ],
     entry = "host",
     federation_shared_config = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",

--- a/src/client/host/BUILD.bazel
+++ b/src/client/host/BUILD.bazel
@@ -11,6 +11,7 @@ build_host(
     ],
     data = [
         "//:package.json",
+        "//src/client/host/404",
         "@npm//:node_modules",
         "@npm//@carto/utils",
     ],

--- a/src/client/host/BUILD.bazel
+++ b/src/client/host/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@npm//webpack-cli:index.bzl", "webpack_cli")
+load("@aspect_rules_swc//swc:swc.bzl", "swc")
 load("@rules_spa//spa:defs.bzl", "build_host")
 
 build_host(
@@ -18,4 +19,15 @@ build_host(
     entry = "host",
     federation_shared_config = "//bazel/js/internals/webpack:webpack.module-federation.shared.js",
     webpack = webpack_cli,
+)
+
+swc(
+    name = "minify",
+    srcs = ["host"],
+    args = [
+        "-C minify=true",
+        "-C jsc.minify.compress=true",
+        "-C jsc.minify.mangle=true",
+    ],
+    output_dir = True,
 )

--- a/src/client/host/bootstrap.tsx
+++ b/src/client/host/bootstrap.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import FederatedRoute from "./FederatedRoute";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Outlet, Link } from "react-router-dom";
 import { NoMatch } from "@internal/404";
 import { getRemoteEntryUrl } from "@carto/utils";
 const path = window.location.pathname;
@@ -38,13 +38,33 @@ for (const route of Object.keys(config)) {
   }
 }
 
+const Layout = () => {
+  return (
+    <div>
+      <nav>
+        <ul>
+          <li>
+            <Link to="/nothing-here">404</Link>
+          </li>
+        </ul>
+      </nav>
+      {/* An <Outlet> renders whatever child route is currently active,
+          so you can think about this <Outlet> as a placeholder for
+          the child routes we defined above. */}
+      <Outlet />
+    </div>
+  );
+};
+
 // root element is defined on the server side
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <Routes>
-        {reactRouterRoutes}
-        <Route path="*" element={<NoMatch />} />
+        <Route path="/" element={<Layout />}>
+          {reactRouterRoutes}
+          <Route path="*" element={<NoMatch />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/client/host/bootstrap.tsx
+++ b/src/client/host/bootstrap.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import FederatedRoute from "./FederatedRoute";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { NoMatch } from "./404/404";
 import { getRemoteEntryUrl } from "@carto/utils";
 const path = window.location.pathname;
 // Find a better way to hydrate this as it isn't really "clean"
@@ -35,18 +36,6 @@ for (const route of Object.keys(config)) {
 
     reactRouterRoutes.push(rrRoute);
   }
-}
-
-function NoMatch() {
-  return (
-    <div>
-      <h2>Nothing to see here!</h2>
-      <br></br>
-      <p>
-        <Link to="/">Go to the home page</Link>
-      </p>
-    </div>
-  );
 }
 
 // root element is defined on the server side

--- a/src/client/host/bootstrap.tsx
+++ b/src/client/host/bootstrap.tsx
@@ -2,8 +2,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import FederatedRoute from "./FederatedRoute";
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
-import { NoMatch } from "./404/404";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { NoMatch } from "@internal/404";
 import { getRemoteEntryUrl } from "@carto/utils";
 const path = window.location.pathname;
 // Find a better way to hydrate this as it isn't really "clean"

--- a/src/client/routes/default.tsx
+++ b/src/client/routes/default.tsx
@@ -9,5 +9,6 @@ export default () => (
     Main Route
     <br></br>
     <Link to="/secondary">Go to second page</Link>
+    <Link to="/404">Go to 404 page</Link>
   </div>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,11 @@
   resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.10.1.tgz#46236a43ad58e310c55247f866da0dc6083c3d8b"
   integrity sha512-IHszNzBO2UrUy6YtsSAsZtnU6I6qpzXGkWdEvGoMxLgJnDsEnsIYniDCUjvjU1KAP+A03eepmCHlyFcRHMSxRA==
 
+"@bazel/esbuild@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@bazel/esbuild/-/esbuild-4.6.0.tgz#68bf9506c104ed4076a0227c4066e3f5df847ee3"
+  integrity sha512-pu4wSBNokYKLisHlXdHxu3UX19vFL4wNQJ45cyekfiWF2szWjWR8x/ZP15a49ChmvP6aelwrURahuhhgzfluOQ==
+
 "@bazel/ibazel@0.15.10":
   version "0.15.10"
   resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.15.10.tgz#cf0cff1aec6d8e7bb23e1fc618d09fbd39b7a13f"


### PR DESCRIPTION

Development mode:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/3680126/153733055-4bd4b582-480d-4069-9701-4048881a6cd2.png">

Production mode:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/3680126/153739197-1b8c5837-e45d-484e-ab21-4313f5deef53.png">
 

This is suppose to toy with the idea of building the graph with ESM output libraries that are then imported into webpack for tree shaking and code splitting. it is a work in progress...

This change also requires `--env production` to be set in `rules_spa` and linked locally so that webpack does dead code elimination without minfication